### PR TITLE
Add PyPi classifiers for Sphinx themes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.6"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Sphinx",
-	"Framework :: Sphinx :: Theme",
+    "Framework :: Sphinx :: Theme",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ requires-python = ">=3.6"
 # Classifiers list: https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 5 - Production/Stable",
+    "Framework :: Sphinx",
+	"Framework :: Sphinx :: Theme",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
That way it shows up with the other Sphinx themes: https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Theme