### PR TITLE
fix link to forkme GitHub banner

### DIFF
--- a/alabaster/layout.html
+++ b/alabaster/layout.html
@@ -101,7 +101,7 @@
 
     {% if theme_github_banner|lower != 'false' %}
     <a href="https://github.com/{{ theme_github_user }}/{{ theme_github_repo }}" class="github">
-        <img style="position: absolute; top: 0; right: 0; border: 0;" src="{{ pathto('_static/' ~ theme_github_banner, 1) if theme_github_banner|lower != 'true' else 'https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png' }}" alt="Fork me on GitHub"  class="github"/>
+        <img style="position: absolute; top: 0; right: 0; border: 0;" src="{{ pathto('_static/' ~ theme_github_banner, 1) if theme_github_banner|lower != 'true' else 'https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png' }}" alt="Fork me on GitHub"  class="github"/>
     </a>
     {% endif %}
 


### PR DESCRIPTION
Addresses [this issue](https://github.com/sphinx-doc/alabaster/issues/208).

Briefly, the GitHub banner has moved to the new URL https://github.blog/wp-content/uploads/2008/12/forkme_right_darkblue_121621.png

This pull request updates `layout.html` to use this new URL rather than old one that no longer has any image.