### PR TITLE
Remove explicit width for search field input

### DIFF
--- a/alabaster/static/alabaster.css_t
+++ b/alabaster/static/alabaster.css_t
@@ -218,10 +218,6 @@ div.sphinxsidebar #searchbox {
     margin: 1em 0;
 }
 
-div.sphinxsidebar #searchbox input[type="text"] {
-    width: 160px;
-}
-
 div.sphinxsidebar .search > div {
     display: table-cell;
 }


### PR DESCRIPTION
Alabaster does not need to adapt the width. Geometry is handled by the basic theme.  In fact, this could cause wrapping of the search button for some magnifications.